### PR TITLE
Get options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,15 @@
 
 A QNX process for broadcasting data over an RN2483 LoRa radio module using a UART connection.
 
-**NOTE:** This program is currently in a dummy format.
-
 ## Usage
 
 See the help documentation with the command: `use broadcaster`
+
+**WARNING:**
+LoRa radio parameters can be set using command-line to the program. You should not assume that the defaults match the
+settings for the CUInSpace ground station. For instance, the ground station assumes cyclic redundancy check to be
+enabled, but it is disabled by default in `broadcaster`. You will need to pass the `-c` flag to enable it.
+
+## Development
+
+Please visit the GitHub wiki for developer resources.

--- a/broadcaster.use
+++ b/broadcaster.use
@@ -6,9 +6,20 @@ are welcome to redistribute it under certain conditions. Please see the GNUGPLv3
 license for more details: https://www.gnu.org/licenses/
 
 DESCRIPTION:
-    A command line utility for broadcasting data over an RN2483 LoRa radio module using UART.
+    A command line utility for broadcasting data over an RN2483 LoRa radio
+    module using UART.
 
 SYNTAX:
-    broadcaster
+    broadcaster [-m mod] [-f freq] [-p pwr] [-s sf] [-r cr] [-b bw]
 
 OPTIONS:
+    -m mod      The modulation for the LoRa radio. Values can be "lora" or
+                "fsk".
+    -f freq     The frequency for the LoRa radio in Hz. Must be within the range
+                433000000-434800000 or 863000000-870000000.
+    -p pwr      The LoRa radio transceiver output power, from -3 to 15.
+    -s sf       The spread factor for the LoRa radio. Must be between 7-12.
+    -r cr       The coding rate of the LoRa radio. Can be one of 4/5, 4/6, 4/7,
+                4/8.
+    -b bw       The bandwidth of the LoRa radio in kHz. Can be one of 125, 200,
+                500.

--- a/broadcaster.use
+++ b/broadcaster.use
@@ -10,7 +10,8 @@ DESCRIPTION:
     module using UART.
 
 SYNTAX:
-    broadcaster [-m mod] [-f freq] [-p pwr] [-s sf] [-r cr] [-b bw]
+    broadcaster [-m mod] [-f freq] [-p pwr] [-s sf] [-r cr] [-b bw] [-l prlen]
+                [-y sync] [-ci]
 
 OPTIONS:
     -m mod      The modulation for the LoRa radio. Values can be "lora" or
@@ -23,3 +24,7 @@ OPTIONS:
                 4/8.
     -b bw       The bandwidth of the LoRa radio in kHz. Can be one of 125, 200,
                 500.
+    -l prlen    The preamble length, within the range 0-65535.
+    -y sync     Sets the sync word. Can be any 64 bit unsigned integer.
+    -c          Turns on cyclic redundancy check.
+    -i          Turns on iqi.

--- a/src/include/radio.h
+++ b/src/include/radio.h
@@ -49,8 +49,16 @@ struct lora_params_t {
     uint64_t sync_word;
 };
 
+/* PARAMETER VALIDATION. */
+bool radio_validate_mod(const char *mod, struct lora_params_t *params);
+bool radio_validate_freq(const char *freq, struct lora_params_t *params);
+bool radio_validate_pwr(const char *power, struct lora_params_t *params);
+bool radio_validate_sf(const char *power, struct lora_params_t *params);
+bool radio_validate_cr(const char *coding_rate, struct lora_params_t *params);
+bool radio_validate_bw(const char *bandwidth, struct lora_params_t *params);
+
+/* RADIO SETUP. */
 void radio_setup_tty(struct termios *tty);
-void radio_set_timeout(uint64_t timeout);
 bool radio_set_params(int radio_fd, const struct lora_params_t *params);
 bool wait_for_ok(int radio_fd);
 

--- a/src/include/radio.h
+++ b/src/include/radio.h
@@ -55,7 +55,9 @@ bool radio_validate_freq(const char *freq, struct lora_params_t *params);
 bool radio_validate_pwr(const char *power, struct lora_params_t *params);
 bool radio_validate_sf(const char *power, struct lora_params_t *params);
 bool radio_validate_cr(const char *coding_rate, struct lora_params_t *params);
+bool radio_validate_prlen(const char *prlen, struct lora_params_t *params);
 bool radio_validate_bw(const char *bandwidth, struct lora_params_t *params);
+bool radio_validate_sync(const char *sync, struct lora_params_t *params);
 
 /* RADIO SETUP. */
 void radio_setup_tty(struct termios *tty);

--- a/src/main.c
+++ b/src/main.c
@@ -7,8 +7,23 @@
 #include <termios.h>
 #include <unistd.h>
 
+/** The read buffer size for incoming data. */
 #define BUFFER_SIZE 250
+
+/**
+ * A macro for exiting with a failure when validation fails.
+ * @param vfunc The validation function, which should take optarg and radio_parameters as parameters.
+ * @param message The message to be printed when validation fails. Should include a %s option for optarg.
+ * */
+#define validate_param(vfunc, message)                                                                                 \
+    if (!vfunc(optarg, &radio_parameters)) {                                                                           \
+        fprintf(stderr, message, optarg);                                                                              \
+        exit(EXIT_FAILURE);                                                                                            \
+    }
+
+/** The device name of the serial port connected to the LoRa radio. */
 static const char serial_port[] = "/dev/ser3";
+/** The default radio parameters. */
 static struct lora_params_t radio_parameters = {.modulation = LORA,
                                                 .frequency = 433050000,
                                                 .power = 15,
@@ -16,50 +31,44 @@ static struct lora_params_t radio_parameters = {.modulation = LORA,
                                                 .coding_rate = CR_4_7,
                                                 .bandwidth = 500,
                                                 .preamble_len = 6,
-                                                .cyclic_redundancy = true,
+                                                .cyclic_redundancy = false,
                                                 .iqi = false,
                                                 .sync_word = 0x43};
 
 int main(int argc, char **argv) {
 
     int c;
-    while ((c = getopt(argc, argv, ":m:f:p:s:r:b:")) != 0) {
+    while ((c = getopt(argc, argv, ":m:f:p:s:r:b:l:ciy:")) != -1) {
         switch (c) {
         case 'm':
-            if (!radio_validate_mod(optarg, &radio_parameters)) {
-                fprintf(stderr, "Unknown modulation setting '%s'", optarg);
-                exit(EXIT_FAILURE);
-            }
+            validate_param(radio_validate_mod, "Invalid modulation type '%s'\n");
             break;
         case 'f':
-            if (!radio_validate_freq(optarg, &radio_parameters)) {
-                fprintf(stderr, "Bad frequency setting '%s'", optarg);
-                exit(EXIT_FAILURE);
-            }
+            validate_param(radio_validate_freq, "Invalid frequency value '%s'\n");
             break;
         case 'p':
-            if (!radio_validate_pwr(optarg, &radio_parameters)) {
-                fprintf(stderr, "Bad power setting '%s'", optarg);
-                exit(EXIT_FAILURE);
-            }
+            validate_param(radio_validate_pwr, "Invalid power value '%s'\n");
             break;
         case 's':
-            if (!radio_validate_sf(optarg, &radio_parameters)) {
-                fprintf(stderr, "Bad spread factor '%s'", optarg);
-                exit(EXIT_FAILURE);
-            }
+            validate_param(radio_validate_sf, "Invalid spread factor '%s'\n");
             break;
         case 'r':
-            if (!radio_validate_cr(optarg, &radio_parameters)) {
-                fprintf(stderr, "Bad coding rate '%s'", optarg);
-                exit(EXIT_FAILURE);
-            }
+            validate_param(radio_validate_cr, "Invalid coding rate '%s'\n");
             break;
         case 'b':
-            if (!radio_validate_bw(optarg, &radio_parameters)) {
-                fprintf(stderr, "Invalid bandwidth '%s'", optarg);
-                exit(EXIT_FAILURE);
-            }
+            validate_param(radio_validate_bw, "Invalid bandwidth value '%s'\n");
+            break;
+        case 'l':
+            validate_param(radio_validate_prlen, "Invalid preamble length '%s'\n");
+            break;
+        case 'y':
+            validate_param(radio_validate_sync, "Invalid sync word '%s'\n");
+            break;
+        case 'c':
+            radio_parameters.cyclic_redundancy = true;
+            break;
+        case 'i':
+            radio_parameters.iqi = true;
             break;
         case ':':
             fprintf(stderr, "Option -%c requires an argument.", optopt);
@@ -72,10 +81,10 @@ int main(int argc, char **argv) {
         }
     }
 
-    int radio = open(serial_port, O_RDWR | O_NDELAY | O_NOCTTY, O_SYNC);
+    int radio = open(serial_port, O_RDWR | O_NDELAY | O_NOCTTY);
 
-    if (radio == -1 || !isatty(radio)) {
-        fprintf(stderr, "Could not open tty.");
+    if (radio == -1) {
+        fprintf(stderr, "Could not open tty with error %d\n.", radio);
         exit(EXIT_FAILURE);
     }
 
@@ -94,6 +103,7 @@ int main(int argc, char **argv) {
         close(radio);
         exit(EXIT_FAILURE);
     }
+    tcflush(radio, TCIFLUSH); // Flush all unread messages from radio
 
     // Set radio parameters
     bool success = radio_set_params(radio, &radio_parameters);

--- a/src/radio.c
+++ b/src/radio.c
@@ -64,7 +64,9 @@ bool radio_validate_mod(const char *mod, struct lora_params_t *params) {
 bool radio_validate_freq(const char *freq, struct lora_params_t *params) {
     char *end;
     uint32_t p_freq = strtoul(freq, &end, 10);
-    if (!(LL_FREQ <= p_freq && p_freq <= LH_FREQ) && !(HL_FREQ <= p_freq <= HH_FREQ)) return false;
+    if (errno || freq == end) return false; // Call failed
+
+    if (!(LL_FREQ <= p_freq && p_freq <= LH_FREQ) && !(HL_FREQ <= p_freq && p_freq <= HH_FREQ)) return false;
 
     params->frequency = p_freq;
     return true;
@@ -94,6 +96,8 @@ bool radio_validate_pwr(const char *power, struct lora_params_t *params) {
 bool radio_validate_sf(const char *sf, struct lora_params_t *params) {
     char *end;
     uint8_t sf_p = strtoul(sf, &end, 10);
+    if (errno || sf == end) return false; // Call failed
+
     if (L_SF <= sf_p && sf_p <= H_SF) {
         params->spread_factor = sf_p;
         return true;
@@ -118,15 +122,30 @@ bool radio_validate_cr(const char *coding_rate, struct lora_params_t *params) {
 }
 
 /**
+ * Validates and sets a command line argument for preamble length.
+ * @param prlen The command line argument for preamble length.
+ * @param params The LoRa parameters to be updated.
+ * @return True if the preamble length was valid and has been set in the params, false otherwise.
+ * */
+bool radio_validate_prlen(const char *prlen, struct lora_params_t *params) {
+    char *end;
+    uint16_t prlen_p = strtoul(prlen, &end, 10);
+    if (errno || prlen == end) return false; // Call failed
+
+    params->preamble_len = prlen_p;
+    return true;
+}
+
+/**
  * Validates and sets a command line argument for bandwidth.
  * @param bandwidth The command line argument for bandwidth.
  * @param params The LoRa parameters to be updated.
  * @return True if the bandwidth was valid and has been set in the params, false otherwise.
  * */
 bool radio_validate_bw(const char *bandwidth, struct lora_params_t *params) {
-    // Parse bandwidth into an unsigned int
     char *end;
     uint16_t bw_p = strtoul(bandwidth, &end, 10);
+    if (errno || bandwidth == end) return false; // Call failed
 
     // Check if it's an option
     for (uint8_t i = 0; i < array_len(BANDWIDTHS); i++) {
@@ -136,6 +155,20 @@ bool radio_validate_bw(const char *bandwidth, struct lora_params_t *params) {
         }
     }
     return false;
+}
+
+/**
+ * Validates and sets a command line argument for sync word.
+ * @param sync The command line argument for sync word.
+ * @param params The LoRa parameters to be updated.
+ * @return True if the sync word was valid and has been set in the params, false otherwise.
+ * */
+bool radio_validate_sync(const char *sync, struct lora_params_t *params) {
+    char *end;
+    uint64_t sync_p = strtoul(sync, &end, 10);
+    if (errno || sync == end) return false; // Call failed
+    params->sync_word = sync_p;
+    return true;
 }
 
 /**


### PR DESCRIPTION
This PR adds the functionality for all radio parameters to be modified using command line arguments. Radio parameters can all be set successfully and data can be transmitted.

Note that the default value for cyclic redundancy check `-c` is disabled, which does not match the setting on the ground station. This is because crc and iqi must remain disabled by default in order to be enabled by the `-c` or `-i` flags respectively.