### PR TITLE
Configurable device descriptor.

### DIFF
--- a/broadcaster.use
+++ b/broadcaster.use
@@ -15,7 +15,10 @@ DESCRIPTION:
 
 SYNTAX:
     broadcaster [-m mod] [-f freq] [-p pwr] [-s sf] [-r cr] [-b bw] [-l prlen]
-                [-y sync] [-i file] [-cq]
+                [-y sync] [-i file] [-cq] device
+
+ARGUMENTS:
+    device      The device descriptor for the RN2483 LoRa module/UART port.
 
 OPTIONS:
     -m mod      The modulation for the LoRa radio. Values can be "lora" or

--- a/src/main.c
+++ b/src/main.c
@@ -27,7 +27,8 @@ static char buffer[BUFFER_SIZE] = {0};
     }
 
 /** The device name of the serial port connected to the LoRa radio. */
-static const char serial_port[] = "/dev/ser3";
+static char *serial_port = NULL;
+
 /** The default radio parameters. */
 static struct lora_params_t radio_parameters = {.modulation = LORA,
                                                 .frequency = 433050000,
@@ -91,6 +92,13 @@ int main(int argc, char **argv) {
             break;
         }
     }
+
+    /* Positional argument for device descriptor. */
+    if (optind >= argc) {
+        fprintf(stderr, "LoRa module device descriptor is required.\n");
+        exit(EXIT_FAILURE);
+    }
+    serial_port = argv[optind];
 
     /* Open radio for reading and writing. */
     int radio = open(serial_port, O_RDWR | O_NDELAY | O_NOCTTY);


### PR DESCRIPTION
The broadcaster module now takes a positional argument for the device descriptor of the LoRa module (i.e. `/dev/ser3`).

This closes #7.