### PR TITLE
Created radio_tx function

### DIFF
--- a/src/include/radio.h
+++ b/src/include/radio.h
@@ -64,6 +64,9 @@ bool radio_validate_sync(const char *sync, struct lora_params_t *params);
 /* RADIO SETUP. */
 void radio_setup_tty(struct termios *tty);
 bool radio_set_params(int radio_fd, const struct lora_params_t *params);
+
+/* RADIO COMMUNICATION */
 bool wait_for_ok(int radio_fd);
+bool radio_tx(int radio_fd, const char *data);
 
 #endif // _RADIO_H_

--- a/src/main.c
+++ b/src/main.c
@@ -144,12 +144,9 @@ int main(int argc, char **argv) {
 
     /** Read input stream data line by line. */
     while (fgets(buffer, BUFFER_SIZE, instream) != NULL) {
-        dprintf(radio, "radio tx %s\n", buffer); // Re-transmit what was read over radio
-        printf("radio tx %s\n", buffer);
-        tcdrain(radio); // Wait for radio to receive message
 
         // Wait for ok response, but if it fails just log and continue
-        if (!wait_for_ok(radio)) {
+        if (!radio_tx(radio, buffer)) {
             fprintf(stderr, "Failed to transmit %s\n", buffer);
         }
     }

--- a/src/radio.c
+++ b/src/radio.c
@@ -257,3 +257,23 @@ bool wait_for_ok(int radio_fd) {
     }
     return false;
 }
+
+/**
+ * Transmits the passed data over LoRa radio.
+ * @param radio_fd The file descriptor to the LoRa radio device.
+ * @param data A pointer to the data to be sent over radio.
+ * @return True if the data was transmitted successfully, false otherwise.
+ */
+bool radio_tx(int radio_fd, const char *data) {
+    dprintf(radio_fd, "mac pause\n"); // Mac pause to not reset parameters
+    tcdrain(radio_fd);                // Wait for radio to process mac pause command
+
+    // Check that mac pause returned non-0 (success)
+    char buffer[10] = {0};
+    read(radio_fd, buffer, sizeof(buffer));
+    if (!strcmp(buffer, "0")) return false; // If 0 is the string then return false
+
+    dprintf(radio_fd, "radio tx %s\n", data); // Transmit data
+    tcdrain(radio_fd);                        // Wait for radio to process transmit request
+    return wait_for_ok(radio_fd);             // Return result of radio response
+}


### PR DESCRIPTION
This PR adds a `radio_tx` function which includes the `mac pause` command.

This closes #5, and seemingly also closes #2.